### PR TITLE
Allow transformations at record (de)serialization time

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-1.3.7-SNAPSHOT
+1.4.0-criteo

--- a/dfs-datastores/src/main/java/com/backtype/hadoop/datastores/TimeSliceStructure.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/datastores/TimeSliceStructure.java
@@ -6,7 +6,7 @@ import com.backtype.support.Utils;
 import java.util.Collections;
 import java.util.List;
 
-public abstract class TimeSliceStructure<T> implements PailStructure<T> {
+public abstract class TimeSliceStructure<T> extends PailStructure<T> {
 
     public final boolean isValidTarget(String... dirs) {
         if(dirs.length < 2) {

--- a/dfs-datastores/src/main/java/com/backtype/hadoop/pail/BinaryPailStructure.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/pail/BinaryPailStructure.java
@@ -1,6 +1,6 @@
 package com.backtype.hadoop.pail;
 
-public abstract class BinaryPailStructure implements PailStructure<byte[]> {
+public abstract class BinaryPailStructure extends PailStructure<byte[]> {
     public byte[] deserialize(byte[] serialized) {
         return serialized;
     }
@@ -14,5 +14,4 @@ public abstract class BinaryPailStructure implements PailStructure<byte[]> {
     public Class getType() {
         return EMPTY_BYTE_ARRAY.getClass();
     }
-
 }

--- a/dfs-datastores/src/main/java/com/backtype/hadoop/pail/Pail.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/pail/Pail.java
@@ -172,7 +172,7 @@ public class Pail<T> extends AbstractPail implements Iterable<T>{
                 if(!spec.equals(existing))
                     throw new IllegalArgumentException("Specs do not match " + spec.toString() + ", " + existing.toString());
             } else if(spec.getStructure()!=null) {
-                if(existing.getStructure()==null || !spec.getStructure().getClass().equals(existing.getStructure().getClass())) {
+                if(existing.getStructure()==null || !spec.getStructure().getSerializationClassName().equals(existing.getStructure().getSerializationClassName())) {
                     throw new IllegalArgumentException("Specs do not match " + spec.toString() + ", " + existing.toString());
                 }
             }

--- a/dfs-datastores/src/main/java/com/backtype/hadoop/pail/PailSpec.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/pail/PailSpec.java
@@ -1,5 +1,6 @@
 package com.backtype.hadoop.pail;
 
+import com.google.common.base.Function;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
@@ -36,6 +37,12 @@ public class PailSpec implements Writable, Serializable {
         this(name, args, null);
     }
 
+    public <U, T>PailSpec(String name, Map<String, Object> args, PailStructure<T> structure,
+                    Function<U, T> preSerialisation,
+                    Function<T, U> postDeserialization) {
+        this(name, args, new TransparentConvertionPailStructure(structure, preSerialisation, postDeserialization));
+    }
+
     public PailSpec(String name, Map<String, Object> args, PailStructure structure) {
         this.name = name;
         this.args = args == null ? null : new HashMap(args);
@@ -67,7 +74,7 @@ public class PailSpec implements Writable, Serializable {
         PailSpec ps = (PailSpec) obj;
         return name.equals(ps.name) &&
                args.equals(ps.args) &&
-               getStructure().getClass().equals(ps.getStructure().getClass());
+               getStructure().getSerializationClassName().equals(ps.getStructure().getSerializationClassName());
     }
 
     @Override
@@ -128,7 +135,7 @@ public class PailSpec implements Writable, Serializable {
         format.put("format", name);
         format.put("args", args);
         if(structure!=null) {
-            format.put("structure", structure.getClass().getName());
+            format.put("structure", structure.getSerializationClassName());
         }
         return format;
     }

--- a/dfs-datastores/src/main/java/com/backtype/hadoop/pail/PailStructure.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/pail/PailStructure.java
@@ -6,10 +6,14 @@ import java.util.List;
 /**
  * Shouldn't take any args
  */
-public interface PailStructure<T> extends Serializable {
-    public boolean isValidTarget(String... dirs);
-    public T deserialize(byte[] serialized);
-    public byte[] serialize(T object);
-    public List<String> getTarget(T object);
-    public Class getType();
+public abstract class PailStructure<T> implements Serializable {
+    abstract public boolean isValidTarget(String... dirs);
+    abstract public T deserialize(byte[] serialized);
+    abstract public byte[] serialize(T object);
+    abstract public List<String> getTarget(T object);
+    abstract public Class getType();
+    public String getSerializationClassName() {
+        return getClass().getName();
+    }
 }
+

--- a/dfs-datastores/src/main/java/com/backtype/hadoop/pail/TransparentConvertionPailStructure.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/pail/TransparentConvertionPailStructure.java
@@ -1,0 +1,66 @@
+package com.backtype.hadoop.pail;
+
+import com.google.common.base.Function;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.List;
+
+public class TransparentConvertionPailStructure<T, U> extends PailStructure<U> {
+
+    private final PailStructure<T> wrappedStructure;
+    private final Function<U, T> preSerialisation;
+    private final Function<T, U> postDeserialization;
+    public Class<U> typeOfRecord;
+
+    /**
+     *
+     * @param wrappedStructure underlying structure used to de/serialize and targeting.
+     * @param preSerialisation U -> T conversion applied to the result of
+     *        {@code wrappedStructure.serialize}
+     * @param postDeserialization T -> U conversion applied to the result of
+     *        {@code wrappedStructure.deserialize}
+     * @return a PailStructure that behaves like {@code wrappedStructure} with the
+     * added behaviour of the two functions parameters. From outside (in the pail metadata file),
+     * the resulting {@code PailStructure} will mimic the {@code wrappedStructure}
+     */
+    public TransparentConvertionPailStructure(PailStructure<T> wrappedStructure,
+                                              Function<U, T> preSerialisation,
+                                              Function<T, U> postDeserialization) {
+        this.wrappedStructure = wrappedStructure;
+        this.preSerialisation = preSerialisation;
+        this.postDeserialization = postDeserialization;
+    }
+
+    @Override
+    public boolean isValidTarget(String... dirs) {
+        return wrappedStructure.isValidTarget(dirs);
+    }
+
+    @Override
+    public U deserialize(byte[] serialized) {
+        return postDeserialization.apply(wrappedStructure.deserialize(serialized));
+    }
+
+    @Override
+    public byte[] serialize(U object) {
+        T t = preSerialisation.apply(object);
+
+        return wrappedStructure.serialize(t);
+    }
+
+    @Override
+    public List<String> getTarget(U object) {
+        T t = preSerialisation.apply(object);
+        return wrappedStructure.getTarget(t);
+    }
+
+    @Override
+    public Class getType() {
+        return wrappedStructure.getType();
+    }
+
+    @Override
+    public String getSerializationClassName() {
+        return wrappedStructure.getSerializationClassName();
+    }
+}

--- a/dfs-datastores/src/test/java/com/backtype/hadoop/pail/PailTest.java
+++ b/dfs-datastores/src/test/java/com/backtype/hadoop/pail/PailTest.java
@@ -15,6 +15,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import static com.backtype.support.TestUtils.*;
 
+import static com.backtype.hadoop.pail.PailOpsTest.wrapStructureWithIdTrans;
 
 public class PailTest extends TestCase {
     FileSystem local;
@@ -211,17 +212,17 @@ public class PailTest extends TestCase {
         assertTrue(pail.isEmpty());
     }
 
-    public void testStructureConstructor() throws Exception {
+    public void testStructureConstructor(boolean wrapStructure) throws Exception {
         String path = getTmpPath(local, "pail");
-        Pail p = Pail.create(local, path, new TestStructure());
+        Pail p = Pail.create(local, path, wrapStructureWithIdTrans(new TestStructure(), wrapStructure));
         PailSpec spec = p.getSpec();
         assertNotNull(spec.getName());
-        assertEquals(TestStructure.class, spec.getStructure().getClass());
+        assertEquals(TestStructure.class, spec.getStructure().getSerializationClassName());
         //shouldn't throw exceptions...
-        Pail.create(local, path, new TestStructure(), false);
+        Pail.create(local, path, wrapStructureWithIdTrans(new TestStructure(), wrapStructure), false);
         Pail.create(local, path, false);
         try {
-            Pail.create(local, path, new DefaultPailStructure(), false);
+            Pail.create(local, path, wrapStructureWithIdTrans(new DefaultPailStructure(), wrapStructure), false);
             fail("should throw exception");
         } catch(IllegalArgumentException e) {
 
@@ -229,7 +230,7 @@ public class PailTest extends TestCase {
         path = getTmpPath(local, "pail");
         Pail.create(local, path);
         try {
-            Pail.create(local, path, new TestStructure(), false);
+            Pail.create(local, path, wrapStructureWithIdTrans(new TestStructure(), wrapStructure), false);
             fail("should throw exception");
         } catch(IllegalArgumentException e) {
 
@@ -248,9 +249,9 @@ public class PailTest extends TestCase {
         return ret;
     }
 
-    public void testStructured() throws Exception {
+    public void testStructured(boolean wrapStructure) throws Exception {
         String path = getTmpPath(local, "pail");
-        Pail<String> pail = Pail.create(local, path, PailFormatFactory.getDefaultCopy().setStructure(new TestStructure()));
+        Pail<String> pail = Pail.create(local, path, PailFormatFactory.getDefaultCopy().setStructure(wrapStructureWithIdTrans(new TestStructure(), wrapStructure)));
         Pail<String>.TypedRecordOutputStream os = pail.openWrite();
         os.writeObject("a1");
         os.writeObject("b1");

--- a/dfs-datastores/src/test/java/com/backtype/hadoop/pail/TestStructure.java
+++ b/dfs-datastores/src/test/java/com/backtype/hadoop/pail/TestStructure.java
@@ -3,7 +3,7 @@ package com.backtype.hadoop.pail;
 import java.util.ArrayList;
 import java.util.List;
 
-public class TestStructure implements PailStructure<String> {
+public class TestStructure extends PailStructure<String> {
 
     public boolean isValidTarget(String... dirs) {
         if (dirs.length == 0) {

--- a/dfs-datastores/src/test/java/com/backtype/hadoop/pail/TransparentConvertionPailStructureTest.java
+++ b/dfs-datastores/src/test/java/com/backtype/hadoop/pail/TransparentConvertionPailStructureTest.java
@@ -1,0 +1,118 @@
+package com.backtype.hadoop.pail;
+
+import com.google.common.base.Function;
+import com.google.common.base.Functions;
+import junit.framework.TestCase;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class TransparentConvertionPailStructureTest extends TestCase {
+
+    public void testIsValidTargetIdentityLaw() throws Exception {
+        checkIdentityLaw("isValid", new Function<PailStructure<String>, Object>() {
+            @Override
+            public Object apply(PailStructure<String> pailStructure) {
+                return pailStructure.isValidTarget("/path/to/smth");
+            }
+        });
+    }
+
+    public void testDeserializeIdentityLaw() throws Exception {
+        checkIdentityLaw("deserialize", new Function<PailStructure<String>, String>() {
+            @Override
+            public String apply(PailStructure<String> pailStructure) {
+                return pailStructure.deserialize("bytesBytesBYTES".getBytes());
+            }
+        });
+    }
+
+    public void testSerializeIdentityLaw() throws Exception {
+        checkIdentityLaw("serialize", new Function<PailStructure<String>, String>() {
+            @Override
+            public String apply(PailStructure<String> pailStructure) {
+                return new String(pailStructure.serialize("bytesBytesBYTES"));
+            }
+        });
+    }
+
+    public void testGetTargetIdentityLaw() throws Exception {
+        checkIdentityLaw("getTarget", new Function<PailStructure<String>, List<String>>() {
+           @Override
+            public List<String> apply(PailStructure<String> pailStructure) {
+                return pailStructure.getTarget("Objectify me");
+            }
+        });
+    }
+
+    public void testGetTypeIdentityLaw() throws Exception {
+        checkIdentityLaw("getType", new Function<PailStructure<String>, Class>() {
+            @Override
+            public Class apply(PailStructure<String> pailStructure) {
+                return pailStructure.getType();
+            }
+        });
+    }
+
+    public void testGetSerializationClassNameIdentityLaw() throws Exception {
+        checkIdentityLaw("getSerializationClassName", new Function<PailStructure<String>, String>() {
+            @Override
+            public String apply(PailStructure<String> pailStructure) {
+                return pailStructure.getSerializationClassName();
+            }
+        });
+    }
+
+    public void testDeserializeComposition() {
+        Function<String, String> uppercase = new Function<String, String>() {
+            @Override
+            public String apply(String o) {
+                return o.toUpperCase();
+            }
+        };
+        PailStructure<String> structure = new PailOpsTest.StringStructure();
+        PailStructure<String> conversionStructure = new TransparentConvertionPailStructure<String, String>(structure,
+                uppercase,
+                Functions.<String>identity()
+        );
+
+
+        String aTestString = "un dos tres";
+
+        assertTrue("serialize . preSerilize x == serialize(preSerialize(x)",
+                Arrays.equals(structure.serialize(uppercase.apply(aTestString)),
+                        conversionStructure.serialize(aTestString)));
+    }
+
+    public void testSerializeComposition() {
+        Function<String, String> uppercase = new Function<String, String>() {
+            @Override
+            public String apply(String o) {
+                return o.toUpperCase();
+            }
+        };
+        PailStructure<String> structure = new PailOpsTest.StringStructure();
+        PailStructure<String> conversionStructure = new TransparentConvertionPailStructure<String, String>(structure,
+                Functions.<String>identity(),
+                uppercase
+        );
+
+
+        byte[] aTestString = "un dos tres".getBytes();
+
+        assertEquals("serialize . preSerilize x == serialize(preSerialize(x)",
+                uppercase.apply(structure.deserialize(aTestString)),
+                conversionStructure.deserialize(aTestString));
+    }
+
+
+    static public <U> void checkIdentityLaw(String name, Function<PailStructure<String>, U> f) {
+        PailStructure<String> structure = new PailOpsTest.StringStructure();
+        PailStructure<String> conversionStructure = new TransparentConvertionPailStructure<String, String>(structure,
+                Functions.<String>identity(),
+                Functions.<String>identity()
+        );
+        assertTrue (name + " should satisfy identity law",
+                f.apply(structure).equals(f.apply(conversionStructure)));
+    }
+}


### PR DESCRIPTION
A new PailStructure wrapping an exisiting instance is provided.
The TransparentConversionPailStructure behaves like the wrapped structure
but applies transformations to (de)serialization output.
In order for Pail to ignore this transformation, the structure field of
a pail metadata file is set to the name of the underlying structure.
This is achieved by replacing usages of "getClass.getString" by a new
method in PailStructure.
To be less disruptive, a default behaviour mimicking the current
logic is provided. It is achieved by turning PailStructure into an
abstract class: API BREAK.
